### PR TITLE
OpenStreetmap zur Anreise verschoben

### DIFF
--- a/content/anreise.md
+++ b/content/anreise.md
@@ -12,8 +12,10 @@ submenu = "yes"
 ---
 Wie auch schon im Sommer 2007 und Winter 2010 findet die ZaPF vom 24. bis 28. Mai 2017 an der Humboldt-Universität zu Berlin auf dem Campus Adlershof statt.
 
-**Anschrift:** Newtonstraße 15, 12489 Berlin
+**Anschrift:** Newtonstraße 15, 12489 Berlin  
 **Koordinaten:** 52.4328527, 13.5296965
+
+<iframe width=100% height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://www.openstreetmap.org/export/embed.html?bbox=13.518612384796143%2C52.427338196064454%2C13.540735244750975%2C52.4385499135805&amp;layer=mapnik&amp;marker=52.43294441135496%2C13.52967381477356" style="border: 1px solid black"></iframe><br/><small><a href="http://www.openstreetmap.org/?mlat=52.4329&amp;mlon=13.5297#map=16/52.4329/13.5297">Größere Karte anzeigen</a></small>
 
 ## Anreise mit dem Auto
 ---

--- a/content/orientierung.md
+++ b/content/orientierung.md
@@ -10,5 +10,4 @@ title = "Orientierung vor Ort"
 ---
 Vom S-Bahnhof Adlershof ist es dann auch nicht mehr weit zum Austragungsort der ZaPF ...
 
-<iframe width=80% height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://www.openstreetmap.org/export/embed.html?bbox=13.518612384796143%2C52.427338196064454%2C13.540735244750975%2C52.4385499135805&amp;layer=mapnik&amp;marker=52.43294441135496%2C13.52967381477356" style="border: 1px solid black"></iframe><br/><small><a href="http://www.openstreetmap.org/?mlat=52.4329&amp;mlon=13.5297#map=16/52.4329/13.5297">Größere Karte anzeigen</a></small>
 


### PR DESCRIPTION
Unter dem Menüpnukt Orientierung soll eine Karte mit genauer Kennzeichnung, wo was ist (Tagungsbüro, Mensa, LCP...). Die OpenStreetMap passt deshalb besser unter Anreise.
