### PR TITLE
Add link and replace [at] by symbol @ in footer mail ([at] is useless…

### DIFF
--- a/themes/sommer17/layouts/partials/foot.html
+++ b/themes/sommer17/layouts/partials/foot.html
@@ -4,7 +4,7 @@
 						<div id="left">
 							<h3>Kontakt</h3>
 							<p>Fachschaft Physik</br>Humboldt-Universität zu Berlin</br>Institut für Physik</br>Newtonstraße 15</br>12489 Berlin</p>
-							<p><b>E-Mail:</b> orga[at]zapf.in-berlin.de</p>
+							<p><b>E-Mail:</b> <a href="mailto:orga@zapf.in-berlin.de">orga@zapf.in-berlin.de</a></p>
 						</div>
 						<div id="center">
 							<h3> Social</h3>


### PR DESCRIPTION
… nowadays).